### PR TITLE
Fix service restart handling

### DIFF
--- a/app/src/main/java/com/hdmi/launcher/HdmiSwitcherService.java
+++ b/app/src/main/java/com/hdmi/launcher/HdmiSwitcherService.java
@@ -18,7 +18,7 @@ public class HdmiSwitcherService extends Service {
             } catch (Exception e) {
                 Log.e("HDMITEST", "Ошибка при эмуляции keyevent: " + Log.getStackTraceString(e));
             }
-            stopSelf();
+            stopSelf(startId);
         }).start();
 
         // Не пересоздавать сервис


### PR DESCRIPTION
## Summary
- avoid premature stop when HdmiSwitcherService receives multiple start commands

## Testing
- `./gradlew --version` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685548440308832088c5774ae5e70a63